### PR TITLE
Define custom Container to plot the waveform

### DIFF
--- a/videojs.wavesurfer.js
+++ b/videojs.wavesurfer.js
@@ -198,7 +198,12 @@
             }
 
             // set waveform element and dimensions
-            opts.container = this.el();
+            // Set the container to player's container if "container" option is not provided
+            // If a waveform needs to be appended to your custom element, then use below option
+            // <code>container: document.querySelector("#vjs-waveform")</code>
+            if (opts.container === undefined) {
+                opts.container = this.el();
+            }
             opts.height = this.player().height() - controlBarHeight;
 
             // customize waveform appearance


### PR DESCRIPTION
Videojs-Wavesurfer uses wavesurfer.js internally. Wavesurfer.js does have an option to plot the waveform in any custom document selector. But Videojs-Wavesurfer hardcodes options.container and does not have the flexibility to change. 

This is a change to have this flexibility and fall back to player itself in case the container option is not provided.