### PR TITLE
Updated load function to optionally load an array of prerendered peak data

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ var player = videojs('myClip',
     plugins: {
         wavesurfer: {
             src: 'media/hal.wav',
+            peaks: 'media/hal.json',
             msDisplayMax: 10,
             debug: true,
             waveColor: 'grey',
@@ -97,6 +98,7 @@ The additional options for this plugin are:
 | option | type | default | description |
 | --- | --- | --- | --- |
 | `src` | string | `null` | The URL of the audio/video file or `'live'` when [using the microphone plugin](#microphone-plugin).|
+| `peaks` | string | `null` | The URL of the JSON file with peak data corresponding to the source audio/video file. This allows the waveform to be created from pre-rendered peak data. This file can be generated using the [bbc/audiowaveform](https://github.com/bbc/audiowaveform) utility. Note that no peak data file is provided in the examples/media directory as the audio file hal.wav is not long enough to justify the use of pre-rendered peak data. |
 | `debug` | boolean | `false` | Display internal log messages using the `videojs.log` method. |
 | `msDisplayMax` | float | `3` | Indicates the number of seconds that is considered the boundary value for displaying milliseconds in the time controls. An audio clip with a total length of 2 seconds and a `msDisplayMax` of 3 will use the format `M:SS:MMM`. Clips with a duration that is longer than `msDisplayMax` will be displayed as `M:SS` or `HH:MM:SS`.|
 

--- a/src/js/videojs.wavesurfer.js
+++ b/src/js/videojs.wavesurfer.js
@@ -260,7 +260,6 @@ class Wavesurfer extends Plugin {
             this.log('Loading object: ' + JSON.stringify(url));
             this.surfer.loadBlob(url);
         } else {
-            this.log('Loading URL: ' + url + '\nLoading Peak Data URL: ' + peakUrl);
             // Load peak data from file
             if (peakUrl !== undefined) {
                 let ajax = WaveSurfer.util.ajax({
@@ -270,9 +269,11 @@ class Wavesurfer extends Plugin {
 
                 ajax.on('success', (data, e) => {
                     if (e.target.status == 200) {
+                        this.log('Loading URL: ' + url + '\nLoading Peak Data URL: ' + peakUrl);
                         this.surfer.load(url, data.data);
                     } else {
-                        this.log("Unable to retrieve peak data. Status code: " + e.target.status);
+                        this.log("Unable to retrieve peak data from" + peakUrl + ". Status code: " + e.target.status);
+                        this.log('Loading URL: ' + url);
                         this.surfer.load(url);
                     }
                 });

--- a/src/js/videojs.wavesurfer.js
+++ b/src/js/videojs.wavesurfer.js
@@ -252,31 +252,33 @@ class Wavesurfer extends Plugin {
      *
      * @param {string|blob|file} url - Either the URL of the audio file,
      *     a Blob or a File object.
+     *
+     * @param {string} peakUrl - The URL of peak data for the audio file.
      */
-    load(audioUrl, peakUrl) {
-        let player = this;
-        if (audioUrl instanceof Blob || audioUrl instanceof File) {
-            player.log('Loading object: ' + JSON.stringify(audioUrl));
-            player.surfer.loadBlob(audioUrl);
+    load(url, peakUrl) {
+        if (url instanceof Blob || url instanceof File) {
+            this.log('Loading object: ' + JSON.stringify(url));
+            this.surfer.loadBlob(url);
         } else {
-            player.log('Loading URL: ' + audioUrl + '\nLoading Peak Data URL: ' + peakUrl);
+            this.log('Loading URL: ' + url + '\nLoading Peak Data URL: ' + peakUrl);
             // Load peak data from file
             if (peakUrl !== undefined) {
-                let request = new XMLHttpRequest();
-                request.onload = function() {
-                    if (request.status == 200) {
-                        player.surfer.load(audioUrl, JSON.parse(request.responseText).data);
+                let ajax = WaveSurfer.util.ajax({
+                    url: peakUrl,
+                    responseType: 'json'
+                });
+
+                ajax.on('success', (data, e) => {
+                    if (e.target.status == 200) {
+                        this.surfer.load(url, data.data);
                     } else {
-                        player.log("Unable to retrieve peak data. Status code: " + request.status);
-                        player.surfer.load(audioUrl);
+                        this.log("Unable to retrieve peak data. Status code: " + e.target.status);
+                        this.surfer.load(url);
                     }
-                };
-                request.open('GET', peakUrl, true);
-                request.send(null);
-            }
-            else {
-                player.log('Loading URL: ' + audioUrl);
-                player.surfer.load(audioUrl);
+                });
+            } else {
+                this.log('Loading URL: ' + url);
+                this.surfer.load(url);
             }
         }
     }


### PR DESCRIPTION
Wavesurfer allows for an optional array of peak data to be passed to the load function. This allows the waveform to be generated much quicker for large audio files. I've updated the plugin to accommodate this feature.