### PR TITLE
Add support for text tracks

### DIFF
--- a/examples/sample.vtt
+++ b/examples/sample.vtt
@@ -1,0 +1,9 @@
+WEBVTT
+
+NOTE Paragraph
+
+00:00:01.137 --> 00:00:05.250
+This mission is too important for me to allow you to jeopardize it
+
+00:00:06.500 --> 00:00:08.002
+I don't know what you're talking about, Hal

--- a/examples/texttrack.html
+++ b/examples/texttrack.html
@@ -22,8 +22,8 @@
 </head>
 <body>
 
-<audio id="myAudio" class="video-js vjs-default-skin">
-    <track type="caption" src="sample.vtt" srclang="en-US" />
+<audio id="myAudio" src="media/hal.wav" class="video-js vjs-default-skin">
+    <track kind="captions" src="sample.vtt" srclang="en-US"/>
 </audio>
 
 <script>
@@ -44,8 +44,7 @@
                 cursorColor: 'black',
                 hideScrollbar: true
             }
-        },
-        techOrder: ["wavesurferTech", "other supported tech"]
+        }
     });
 
     // error handling

--- a/examples/texttrack.html
+++ b/examples/texttrack.html
@@ -22,7 +22,7 @@
 </head>
 <body>
 
-<audio id="myAudio" src="media/hal.wav" class="video-js vjs-default-skin">
+<audio id="myAudio" class="video-js vjs-default-skin">
     <track kind="captions" src="sample.vtt" srclang="en-US"/>
 </audio>
 

--- a/examples/texttrack.html
+++ b/examples/texttrack.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Wavesurfer Plugin for Video.js Example</title>
+
+    <link href="../node_modules/video.js/dist/video-js.min.css" rel="stylesheet">
+    <link href="../dist/css/videojs.wavesurfer.css" rel="stylesheet">
+
+    <script src="../node_modules/video.js/dist/video.min.js"></script>
+    <script src="../node_modules/wavesurfer.js/dist/wavesurfer.min.js"></script>
+
+    <script src="../dist/videojs.wavesurfer.js"></script>
+
+    <style>
+        /* change player background color */
+        #myAudio {
+            background-color: #FFEEFF;
+        }
+    </style>
+
+</head>
+<body>
+
+<audio id="myAudio" class="video-js vjs-default-skin">
+    <track type="caption" src="sample.vtt" srclang="en-US" />
+</audio>
+
+<script>
+    var player = videojs(document.querySelector('audio'), {
+        controls: true,
+        autoplay: true,
+        fluid: false,
+        loop: false,
+        width: 600,
+        height: 300,
+        plugins: {
+            wavesurfer: {
+                src: 'media/hal.wav',
+                msDisplayMax: 10,
+                debug: true,
+                waveColor: 'grey',
+                progressColor: 'black',
+                cursorColor: 'black',
+                hideScrollbar: true
+            }
+        },
+        techOrder: ["wavesurferTech", "other supported tech"]
+    });
+
+    // error handling
+    player.on('error', function(error) {
+        console.warn('ERROR:', error);
+    });
+</script>
+
+</body>
+</html>

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -21,3 +21,14 @@
 button.vjs-play-control.vjs-control.vjs-button {
     cursor: pointer;
 }
+
+/* Ensure that vjs menus and interfaces can be interacted with (such as the closed captions button)
+--------------------------------------------------------------------------------
+*/
+.vjs-menu-content {
+    z-index: 1;
+}
+
+.vjs-modal-dialog, .vjs-text-track-display {
+    z-index: 4;
+}

--- a/src/js/videojs.wavesurfer.js
+++ b/src/js/videojs.wavesurfer.js
@@ -19,7 +19,6 @@ const Html5 = videojs.getTech('Html5');
 
 const wavesurferClassName = 'vjs-wavedisplay';
 
-
 /**
  * Draw a waveform for audio and video files in a video.js player.
  *
@@ -701,6 +700,9 @@ class WavesurferTech extends Html5 {
      *        Callback function to call when the `Flash` Tech is ready.
      */
     constructor(options, ready) {
+        //Never allow for native text tracks, because this isn't actually html5 audio. Native tracks fail because we are using wavesurfer.
+        options.nativeTextTracks = false;
+
         super(options, ready);
 
         //We need the player instance so that we can access the current wavesurfer plugin attached to that player.
@@ -764,8 +766,11 @@ Wavesurfer.VERSION = 'dev';
 videojs.Wavesurfer = Wavesurfer;
 videojs.registerPlugin('wavesurfer', Wavesurfer);
 
-//Register Tech
-videojs.registerTech('wavesurferTech', WavesurferTech);
+/*
+ Register the WavesurferTech as 'Html5' to override the default html5 tech. If we register it as anything
+ other then 'Html5', the <audio> element will be removed by VJS and caption tracks will be lost in safari.
+ */
+videojs.registerTech('Html5', WavesurferTech);
 
 module.exports = {
     Wavesurfer


### PR DESCRIPTION
This creates a 'player technology' (tech) that extends the default HTML5 tech and then replaces the HTML5 tech. By extending the HTML5 tech, we can have it properly emit events that trigger text track functionality in VideoJS.

closes #36 