### PR TITLE
make the tech aware of the player in a safer way

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 videojs-wavesurfer changelog
 ============================
 
+2.2.1 - unreleased
+------------------
+
+- Fix tech for compatibility with video.js 6.7.x (#49 by @mfairchild365)
+
+
 2.2.0 - 2018/01/23
 ------------------
 

--- a/src/js/tech.js
+++ b/src/js/tech.js
@@ -21,10 +21,12 @@ class WavesurferTech extends Html5 {
         options.nativeTextTracks = false;
 
         super(options, ready);
+    }
 
+    setActivePlayer(player) {
         // we need the player instance so that we can access the current
         // wavesurfer plugin attached to that player
-        this.activePlayer = videojs(options.playerId);
+        this.activePlayer = player;
         this.waveready = false;
 
         // track when wavesurfer is fully initialized (ready)

--- a/src/js/videojs.wavesurfer.js
+++ b/src/js/videojs.wavesurfer.js
@@ -74,6 +74,7 @@ class Wavesurfer extends Plugin {
      * Player UI is ready: customize controls.
      */
     initialize() {
+        this.player.tech_.setActivePlayer(this.player);
         this.player.bigPlayButton.hide();
 
         // the native controls don't work for this UI so disable


### PR DESCRIPTION
it looks like calling `videojs(playerId)` or even `videojs.getPlayer(playerId)` from within the tech is now failing. So instead, have the plugin inform the tech about the player after the tech has already been created.

fixes #49 